### PR TITLE
Make it possible to use a username param instead of the name

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,8 @@ Requirements
 Usage
 -----
 
-    httpauth { 'user':
+    httpauth { 'name':
+      username => 'username',
       file     => '/path/to/password/file',
       password => 'password',
       realm => 'realm',

--- a/lib/puppet/provider/httpauth/httpauth.rb
+++ b/lib/puppet/provider/httpauth/httpauth.rb
@@ -9,13 +9,13 @@ Puppet::Type.type(:httpauth).provide(:httpauth) do
 
     def create
         # Create a user in the file we opened in the mech method
-        @htauth.set_passwd(resource[:realm], resource[:name], resource[:password])
+        @htauth.set_passwd(resource[:realm], resource[:username], resource[:password])
         @htauth.flush 
     end
  
     def destroy
         # Delete a user in the file we opened in the mech method
-        @htauth.delete_passwd(resource[:realm], resource[:name])
+        @htauth.delete_passwd(resource[:realm], resource[:username])
         @htauth.flush
     end
  
@@ -26,10 +26,10 @@ Puppet::Type.type(:httpauth).provide(:httpauth) do
             mech(resource[:file])
 
             # Check if the user exists in the file
-            cp = @htauth.get_passwd(resource[:realm], resource[:name], false)
+            cp = @htauth.get_passwd(resource[:realm], resource[:username], false)
             return false if cp == nil
             # Check if the current password matches the proposed password
-            return check_passwd(resource[:realm], resource[:name], resource[:password], cp)
+            return check_passwd(resource[:realm], resource[:username], resource[:password], cp)
         else
             # If the file doesn't exist then create it
             File.new(resource[:file], "w")

--- a/lib/puppet/type/httpauth.rb
+++ b/lib/puppet/type/httpauth.rb
@@ -1,6 +1,7 @@
 Puppet::Type.newtype(:httpauth) do
     @doc = "Manage HTTP Basic or Digest password files." +
-           "    httpauth { 'user':                     " +
+           "    httpauth { 'name':                     " +
+           "      username => user                     " +
            "      file => '/path/to/password/file',    " +
            "      password => 'password',              " +
            "      mechanism => basic,                  " +
@@ -19,7 +20,7 @@ Puppet::Type.newtype(:httpauth) do
        defaultto :present
     end
 
-    newparam(:name) do
+    newparam(:username) do
        desc "The name of the user to be managed."
 
        isnamevar

--- a/lib/puppet/type/httpauth.rb
+++ b/lib/puppet/type/httpauth.rb
@@ -29,7 +29,7 @@ Puppet::Type.newtype(:httpauth) do
     newparam(:username) do
        desc "The name of the user to be managed."
 
-       defaultto :name
+       defaultto { @resource[:name] }
     end 
 
     newparam(:file) do

--- a/lib/puppet/type/httpauth.rb
+++ b/lib/puppet/type/httpauth.rb
@@ -20,10 +20,16 @@ Puppet::Type.newtype(:httpauth) do
        defaultto :present
     end
 
-    newparam(:username) do
+    newparam(:name) do
        desc "The name of the user to be managed."
 
        isnamevar
+    end 
+
+    newparam(:username) do
+       desc "The name of the user to be managed."
+
+       defaultto :name
     end 
 
     newparam(:file) do

--- a/spec/unit/type/httpauth.rb
+++ b/spec/unit/type/httpauth.rb
@@ -4,7 +4,7 @@ require File.dirname(__FILE__) + '/../../spec_helper'
 
 describe Puppet::Type.type(:httpauth) do
     it "should default to being present" do
-        user = Puppet::Type.type(:httpauth).new(:name => "alice", :password => "password")
+        user = Puppet::Type.type(:httpauth).new(:username => "alice", :password => "password")
         user.should(:ensure).should == :present
     end
 end
@@ -28,19 +28,19 @@ describe Puppet::Type.type(:httpauth), "when validating attribute values" do
     end
 
     it "should support :present as a value to :ensure" do
-        Puppet::Type.type(:httpauth).new(:name => "alice", :ensure => :present, :password => "password")
+        Puppet::Type.type(:httpauth).new(:username => "alice", :ensure => :present, :password => "password")
     end
 
     it "should support :absent as a value to :ensure" do
-        Puppet::Type.type(:httpauth).new(:name => "alice", :ensure => :absent, :password => "password")
+        Puppet::Type.type(:httpauth).new(:username => "alice", :ensure => :absent, :password => "password")
     end
 
     it "should support :basic as a value to :mechanism" do
-        Puppet::Type.type(:httpauth).new(:name => "alice", :mechanism => :basic, :password => "password")
+        Puppet::Type.type(:httpauth).new(:username => "alice", :mechanism => :basic, :password => "password")
     end
 
     it "should support :digest as a value to :mechanism" do
-        Puppet::Type.type(:httpauth).new(:name => "alice", :mechanism => :digest, :password => "password")
+        Puppet::Type.type(:httpauth).new(:username => "alice", :mechanism => :digest, :password => "password")
     end 
 end
 
@@ -55,7 +55,7 @@ describe Puppet::Type.type(:httpauth) do
         @provider = stub 'provider', :class => Puppet::Type.type(:httpauth).defaultprovider, :clear => nil, :satisfies? => true, :name => :mock
         Puppet::Type.type(:httpauth).defaultprovider.stubs(:new).returns(@provider)
         Puppet::Type.type(:httpauth).defaultprovider.stubs(:instances).returns([])
-        @httpauth = Puppet::Type.type(:httpauth).new(:name => "alice", :password => "password")
+        @httpauth = Puppet::Type.type(:httpauth).new(:username => "alice", :password => "password")
 
         @catalog = Puppet::Resource::Catalog.new
         @catalog.add_resource(@httpauth)


### PR DESCRIPTION
If you need the same user with different passwords in multiple files you used to get a duplicated resource, now you can workaround this.