### PR TITLE
Remove duplicate mode parameter

### DIFF
--- a/lib/puppet/type/httpauth.rb
+++ b/lib/puppet/type/httpauth.rb
@@ -36,12 +36,6 @@ Puppet::Type.newtype(:httpauth) do
        desc "The HTTP password file to be managed. If it doesn't exist it is created."
     end
 
-    newparam(:mode) do
-       desc "The desired permissions mode for the file."
-
-       defaultto 0600
-    end
-
     newparam(:password) do
        desc "The password in plaintext."
     


### PR DESCRIPTION
This fixes issue introduced in #9 which added duplicate `mode` parameter that already existed further down in the file. Duplicate parameters in types causes errors.